### PR TITLE
feat: enable Firefox for Android support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,15 +17,22 @@
     "128": "images/icon-128.png"
   },
   "background": {
-    "scripts": ["src/background/index.js"],
+    "scripts": [
+      "src/background/index.js"
+    ],
     "persistent": false
   },
   "browser_specific_settings": {
     "gecko": {
       "id": "glazenbol@glazenbol.dev",
       "data_collection_permissions": {
-        "required": ["none"]
+        "required": [
+          "none"
+        ]
       }
+    },
+    "gecko_android": {
+      "id": "glazenbol@glazenbol.dev"
     }
   },
   "permissions": [


### PR DESCRIPTION
## Summary
This PR adds support for Firefox on Android by updating [manifest.json](cci:7://file:///home/milo/.code/GlazenBol/manifest.json:0:0-0:0) with the required `gecko_android` configuration.

## Changes
- Added `gecko_android` key to `browser_specific_settings` in [manifest.json](cci:7://file:///home/milo/.code/GlazenBol/manifest.json:0:0-0:0).
- Preserved the existing extension ID (`glazenbol@glazenbol.dev`) to ensure the extension is declared as the same add-on across platforms.

## Verification
- Verified [manifest.json](cci:7://file:///home/milo/.code/GlazenBol/manifest.json:0:0-0:0) syntax.
- Confirmed compatibility with Firefox for Android requirements (using independent `gecko_android` key while keeping `gecko` for desktop).

NB: I haven't tested this on Firefox on Android yet, not sure how to do that. I did verify that building as per the readme still works (and ofc initially determined that the existing extension doesn't support FF on Android). Most people shop on their phones, so mobile support would be great I'd say!